### PR TITLE
fix(ssr): allow mocking to fail silently in node env

### DIFF
--- a/__tests__/server-side.js
+++ b/__tests__/server-side.js
@@ -1,0 +1,15 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * test canvas mock in a node environment
+ */
+
+import createCanvas from '../src/canvas';
+
+describe('canvas', () => {
+  test('running in node environment fails silently', () => {
+    expect(createCanvas).toBeDefined();
+  })
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,9 @@ var _window2 = _interopRequireDefault(_window);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // mock global window
-global.window = (0, _window2.default)(window); /**
-                                                * Created by hustcc 17/12/25.
-                                                * Contract: i@hust.cc
-                                                */
+if (typeof window !== 'undefined') {
+  global.window = (0, _window2.default)(window);
+} /**
+   * Created by hustcc 17/12/25.
+   * Contract: i@hust.cc
+   */

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,6 @@
 import mockWindow  from './window';
 
 // mock global window
-global.window = mockWindow(window);
+if (typeof window !== 'undefined') {
+  global.window = mockWindow(window);
+}


### PR DESCRIPTION
Fixes #6

Allows `jest-canvas-mock` to run normally in jsdom environments.

Allows the mocking to fail silently in node environments, which is needed to test components that are rendered both on the client and on the server.