### PR TITLE
Add createImageData() implementation

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -42,6 +42,19 @@ describe('canvas', () => {
     expect(canvas.toDataURL).toHaveBeenLastCalledWith('image/jpeg', 1.0);
   });
 
+  test('canvas.createImageData()', () => {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    const imageData = ctx.createImageData(100, 50);
+    expect(imageData.width).toBe(100);
+    expect(imageData.height).toBe(50);
+    expect(imageData.data).toBeDefined();
+    expect(imageData.data).toHaveLength(20000);
+
+    const imageData2 = ctx.createImageData({width: 120, height: 100});
+    expect(imageData2.data).toHaveLength(48000);
+  });
+
   test('ctx.functions', () => {
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');

--- a/src/classes/context2d.js
+++ b/src/classes/context2d.js
@@ -19,7 +19,17 @@ const context2d = {
     height: 14,
   }),
   putImageData: () => {},
-  createImageData: () => [],
+  createImageData: (w = 1, h = 1) => {
+    if ('object' === typeof w) {
+      h = w.height;
+      w = w.width;
+    }
+    return {
+      width: w,
+      height: h,
+      data: new Array((w * h * 4))
+    }
+  },
   setTransform: () => {},
   resetTransform: () => {},
   drawImage: () => {},


### PR DESCRIPTION
This PR adds handling of parameters to `createImageData()` and returns the correctly-shaped object.