### PR TITLE
Add support for toBlob

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -42,6 +42,13 @@ describe('canvas', () => {
     expect(canvas.toDataURL).toHaveBeenLastCalledWith('image/jpeg', 1.0);
   });
 
+  test('canvas.toBlob()', () => {
+    const canvas = document.createElement('canvas');
+    const callback = jest.fn();
+    expect(canvas.toBlob(callback));
+    expect(canvas.toBlob).toHaveBeenLastCalledWith(callback);
+  });
+
   test('canvas.createImageData()', () => {
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -45,7 +45,10 @@ describe('canvas', () => {
   test('canvas.toBlob()', () => {
     const canvas = document.createElement('canvas');
     const callback = jest.fn();
-    expect(canvas.toBlob(callback));
+    canvas.toBlob();
+    expect(canvas.toBlob).toHaveBeenLastCalledWith();
+
+    canvas.toBlob(callback);
     expect(canvas.toBlob).toHaveBeenLastCalledWith(callback);
   });
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -10,6 +10,7 @@ const createCanvas = () => {
 
   div.getContext = param => param === '2d' ? createContext2d('2d', div) : {};
   div.toDataURL = jest.fn(() => '');
+  div.toBlob = jest.fn(callback => (callback ? callback() : ''));
   return div;
 };
 


### PR DESCRIPTION
This PR adds support for toBlob method:

https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob

Thanks for the library!