### PR TITLE
implement toBlob and toDataURL

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -5,14 +5,105 @@
 import { ver } from '../src';
 import pkg from '../package.json';
 
+let canvas;
+
+beforeEach(() => {
+  canvas = document.createElement('canvas');
+});
+
 describe('canvas', () => {
   test('version', () => {
     expect(ver).toBe(pkg.version);
   });
 
   test('context creation of type 2d returns CanvasRenderingContext2D', () => {
-    const ctx = document.createElement('canvas').getContext('2d');
+    const ctx = canvas.getContext('2d');
     expect(ctx).toBeInstanceOf(CanvasRenderingContext2D);
+  });
+
+  it('should expect getContext to be called', () => {
+    canvas.getContext('2d');
+    expect(canvas.getContext).toBeCalled();
+  });
+
+  it('should have a toBlob function', () => {
+    expect(typeof canvas.toBlob).toBe('function');
+  });
+
+  it('should expect toBlob to be callable', () => {
+    canvas.toBlob(e => {});
+    expect(canvas.toBlob).toBeCalled();
+  });
+
+  it('should expect toBlob to return Blob', () => {
+    return new Promise((resolve, reject) => {
+      canvas.toBlob(e => {
+        var ex;
+        try {
+          expect(e).toBeInstanceOf(window.Blob);
+        } catch (ex) {
+          return reject(ex);
+        }
+        resolve();
+      });
+    })
+  });
+
+  it('should throw if toBlob is provided less than 1 argument', () => {
+    expect(() => canvas.toBlob()).toThrow(TypeError);
+  });
+
+  it('should throw if toBlob is provided with no callback', () => {
+    expect(() => canvas.toBlob(1)).toThrow(TypeError);
+  });
+
+  it('should accept image/jpeg', () => {
+    return new Promise((resolve, reject) => {
+      canvas.toBlob(e => {
+        var ex;
+        try {
+          expect(e.type).toBe('image/jpeg')
+        } catch (ex) {
+          return reject(ex);
+        }
+        resolve();
+      }, 'image/jpeg');
+    });
+  });
+
+  it('should accept image/webp', () => {
+    return new Promise((resolve, reject) => {
+      canvas.toBlob(e => {
+        var ex;
+        try {
+          expect(e.type).toBe('image/webp')
+        } catch (ex) {
+          return reject(ex);
+        }
+        resolve();
+      }, 'image/webp');
+    });
+  });
+
+  it('should have toDataURL function', () => {
+    expect(typeof canvas.toDataURL).toBe('function');
+  });
+
+  it('should expect canvas toDataURL to be callable', () => {
+    canvas.toDataURL();
+    expect(canvas.toDataURL).toBeCalled();
+  });
+
+  it('should expect canvas toDataURL to always return string', () => {
+    expect(canvas.toDataURL()).toBe('data:image/png;base64,00');
+  });
+
+  it('should accept image/jpeg', () => {
+    expect(canvas.toDataURL('image/jpeg')).toMatch(/image\/jpeg/);
+  });
+
+  it('should accept image/webp', () => {
+    expect(canvas.toDataURL('image/webp')).toMatch(/image\/webp/);
   });
 
   test('context creation of any other type returns null', () => {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "jest": {
     "collectCoverage": true,
     "collectCoverageFrom": [
-      "src/classes/**/*.js"
+      "src/classes/**/*.js",
+      "src/mock/**/*.js"
     ],
     "setupFiles": [
       "./src/index.js"

--- a/src/mock/prototype.js
+++ b/src/mock/prototype.js
@@ -1,0 +1,82 @@
+export default function mockPrototype() {
+  /**
+   * Overrides getContext. Every test run will create a new function that overrides the current
+   * value of getContext. It attempts to preserve the original getContext function by storing it on
+   * the callback as a property.
+   */
+  const getContext2D = jest.fn(function getContext2d(type) {
+    if (type === '2d') return new CanvasRenderingContext2D(this);
+    try {
+      require('canvas');
+    } catch {
+      return null;
+    }
+    return getContext2D.internal.call(this, type);
+  });
+
+  if (!jest.isMockFunction(HTMLCanvasElement.prototype.getContext)) {
+    getContext2D.internal = HTMLCanvasElement.prototype.getContext;
+  } else {
+    getContext2D.internal = HTMLCanvasElement.prototype.getContext.internal;
+  }
+  HTMLCanvasElement.prototype.getContext = getContext2D;
+
+  /**
+   * This function technically throws SecurityError at runtime, but it cannot be mocked, because
+   * we don't know if the canvas is tainted. These kinds of errors will be silent.
+   */
+  const toBlobOverride = jest.fn(function toBlobOverride(callback, mimetype) {
+    if (arguments.length < 1) throw new TypeError('Failed to execute \'toBlob\' on \'HTMLCanvasElement\': 1 argument required, but only 0 present.');
+    if (typeof callback !== 'function') throw new TypeError('Failed to execute \'toBlob\' on \'HTMLCanvasElement\': The callback provided as parameter 1 is not a function.');
+
+    /**
+     * Mime type must be image/jpeg or image/webp exactly for the browser to accept it, otherwise
+     * it's image/png.
+     */
+    switch (mimetype) {
+      case 'image/webp': break;
+      case 'image/jpeg': break;
+      default: mimetype = 'image/png';
+    }
+
+    /**
+     * This section creates a blob of size width * height * 4. This is not actually valid, because
+     * jpeg size is variable, and so is png. TODO: Is there a better way to do this?
+     */
+    const length = this.width * this.height * 4;
+    const data = new Uint8Array(length);
+    const blob = new window.Blob([data], { type: mimetype });
+    setTimeout(() => callback(blob), 0);
+  });
+
+  if (!jest.isMockFunction(HTMLCanvasElement.prototype.toBlob)) {
+    toBlobOverride.internal = HTMLCanvasElement.prototype.toBlob;
+  } else {
+    toBlobOverride.internal = HTMLCanvasElement.prototype.toBlob.internal;
+  }
+  HTMLCanvasElement.prototype.toBlob = toBlobOverride;
+
+  /**
+   * This section creates a dataurl with a validated mime type. This is not actually valid, because
+   * jpeg size is variable, and so is png. TODO: Is there a better way to do this?
+   */
+  const toDataURLOverride = jest.fn(function toDataURLOverride(type, encoderOptions) {
+    switch(type) {
+      case 'image/jpeg': break;
+      case 'image/webp': break;
+      default: type = 'image/png';
+    }
+
+    /**
+     * This is the smallest valid data url I could generate.
+     */
+    return 'data:' + type + ';base64,00';
+  });
+
+  if (!jest.isMockFunction(HTMLCanvasElement.prototype.toDataURL)) {
+    toDataURLOverride.internal = HTMLCanvasElement.prototype.toDataURL;
+  } else {
+    toDataURLOverride.internal = HTMLCanvasElement.prototype.toBlob.internal;
+  }
+  HTMLCanvasElement.prototype.toDataURL = toDataURLOverride;
+}

--- a/src/window.js
+++ b/src/window.js
@@ -10,7 +10,7 @@ import CanvasRenderingContext2D from './classes/CanvasRenderingContext2D';
 import DOMMatrix from './classes/DOMMatrix';
 import ImageData from './classes/ImageData';
 import TextMetrics from './classes/TextMetrics';
-
+import mockPrototype from './mock/prototype';
 
 export default win => {
   const d = win.document;
@@ -50,21 +50,6 @@ export default win => {
   if (!win.ImageData) win.ImageData = ImageData;
   if (!win.TextMetrics) win.TextMetrics = TextMetrics;
 
-  const getContext2D = jest.fn(function getContext2d(type) {
-    if (type === '2d') return new CanvasRenderingContext2D(this);
-    try {
-      require('canvas');
-    } catch {
-      return null;
-    }
-    return getContext2D.internal.call(this, type);
-  });
-  if (!jest.isMockFunction(HTMLCanvasElement.prototype.getContext)) {
-    getContext2D.internal = HTMLCanvasElement.prototype.getContext;
-  } else {
-    getContext2D.internal = HTMLCanvasElement.prototype.getContext.internal;
-  }
-  HTMLCanvasElement.prototype.getContext = getContext2D;
-
+  mockPrototype();
   return win;
-};
+}


### PR DESCRIPTION
# Goals
- [x] monkey patch toBlob
- [x] monkey path toDataURL
- [] increase test coverage of prototype mocking functions to 100%
- [x] move mock functions to their own folder
- [x] change codeCoverageFrom in package.json to include `src/mock/**/*.js`
- [x] test toBlob
- [x] test toDataURL

# Problems with implementation

If the `"canvas"` package is installed, we call the internal function provided by jsdom as a `pass-through`. This causes line 14 of `./src/mock/prototype.js` to be uncovered at the moment.

Since we do not install `"canvas"` as a development dependency this branch of code cannot be tested.

@AdriaRios would you mind testing this fork in your test suite? You can clone the repo into your node-modules folder and run:

```
npm install
npm test
npm build
```

# Test Coverage

There is currently only one line of code uncovered in `mock/prototype.js`.

```
------------------------------|----------|----------|----------|----------|-------------------|
File                          |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------------------|----------|----------|----------|----------|-------------------|
All files                     |    99.81 |      100 |      100 |    99.77 |                   |
 classes                      |      100 |      100 |      100 |      100 |                   |
  CanvasGradient.js           |      100 |      100 |      100 |      100 |                   |
  CanvasPattern.js            |      100 |      100 |      100 |      100 |                   |
  CanvasRenderingContext2D.js |      100 |      100 |      100 |      100 |                   |
  DOMMatrix.js                |      100 |      100 |      100 |      100 |                   |
  ImageData.js                |      100 |      100 |      100 |      100 |                   |
  Path2D.js                   |      100 |      100 |      100 |      100 |                   |
  TextMetrics.js              |      100 |      100 |      100 |      100 |                   |
 mock                         |    97.44 |      100 |      100 |    97.14 |                   |
  prototype.js                |    97.44 |      100 |      100 |    97.14 |                14 |
------------------------------|----------|----------|----------|----------|-------------------|
```