### PR TITLE
fix(getcontext): repeated calls to getContext('2d') return same context

### DIFF
--- a/__tests__/mock/prototype.js
+++ b/__tests__/mock/prototype.js
@@ -111,4 +111,10 @@ describe('mock', () => {
     canvas.getContext('webgl');
     console.error = error;
   });
+
+  it('should return the same context if getContext("2d") is called twice', () => {
+    const first = canvas.getContext("2d");
+    const second = canvas.getContext("2d");
+    expect(first).toBe(second);
+  });
 });


### PR DESCRIPTION
This pull request maintains 100% code coverage, fixes standard `HTMLCanvasElement#getContext` behavior.

closes #34 