### PR TITLE
feat(build): add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest --no-cache",
     "build": "babel src --out-dir lib",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "cssfontparser": "^1.2.1",


### PR DESCRIPTION
I'd like to add a "prepare" script so that I can install the module from a github URL.