### PR TITLE
docs(mock): add doc on how to override mock return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ expect(() => ctx.fill(new Path2D(), "invalid!")).toThrow(TypeError);
 
 We try to follow the ECMAScript specification as closely as possible.
 
+## Override default mock return value
+
+You can override the default mock return value in your test to suit your need. For example, to override return value of `toDataURL`:
+
+```ts
+HTMLCanvasElement.prototype.toDataURL = jest
+  .fn()
+  .mockReturnValue(
+    'data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=='
+  );
+```
 
 ## License
 


### PR DESCRIPTION
add a section in the README on how to override the default mock return value