### PR TITLE
fix(context): :anchor: Removes argument to getters

### DIFF
--- a/__tests__/classes/CanvasRenderingContext2D.__getDrawCalls.js
+++ b/__tests__/classes/CanvasRenderingContext2D.__getDrawCalls.js
@@ -14,7 +14,7 @@ const path = new Path2D();
 path.arc(100, 101, 10, 0, Math.PI * 2);
 
 afterEach(() => {
-  const drawCalls = ctx.__getDrawCalls(ctx);
+  const drawCalls = ctx.__getDrawCalls();
   expect(drawCalls).toMatchSnapshot();
 });
 

--- a/__tests__/classes/CanvasRenderingContext2D.__getEvents.js
+++ b/__tests__/classes/CanvasRenderingContext2D.__getEvents.js
@@ -16,7 +16,7 @@ path.arc(100, 101, 10, 0, Math.PI * 2);
 const imgData = new ImageData(100, 100);
 
 afterEach(() => {
-  const drawCalls = ctx.__getEvents(ctx);
+  const drawCalls = ctx.__getEvents();
   expect(drawCalls).toMatchSnapshot();
 });
 

--- a/__tests__/classes/CanvasRenderingContext2D.__getPath.js
+++ b/__tests__/classes/CanvasRenderingContext2D.__getPath.js
@@ -9,7 +9,7 @@ const path = new Path2D();
 path.arc(100, 101, 10, 0, Math.PI * 2);
 
 afterEach(() => {
-  const drawCalls = ctx.__getPath(ctx);
+  const drawCalls = ctx.__getPath();
   expect(drawCalls).toMatchSnapshot();
 });
 

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -47,7 +47,7 @@ export default class CanvasRenderingContext2D {
    * an event is added to this array. This goes for every property set, and draw call.
    */
   _events = [];
-  __getEvents(ctx) {
+  __getEvents() {
     return this._events.slice();
   }
 
@@ -56,8 +56,8 @@ export default class CanvasRenderingContext2D {
    * path.
    */
   _path = [createCanvasEvent('beginPath', [1, 0, 0, 1, 0, 0], {})];
-  __getPath(ctx) {
-    return ctx._path.slice();
+  __getPath() {
+    return this._path.slice();
   }
 
   _directionStack = ['inherit'];


### PR DESCRIPTION
The `__get*` methods on the CanvasRenderingContext2D class currently take an unnecessary `ctx` argument. This is inconsistent with both the README and the TypeScript interface's documentation of these methods. This change removes the argument and updates the tests to match.