### PR TITLE
feat(mock): support clearing draw calls and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ const calls = ctx.__getDrawCalls();
 expect(calls).toMatchSnapshot();
 ```
 
+In some cases it may be useful to clear the events or draw calls that have already been logged.
+
+```ts
+// Clear events
+ctx.__clearEvents();
+
+// Clear draw calls
+ctx.__clearDrawCalls();
+```
+
 ## Override default mock return value
 
 You can override the default mock return value in your test to suit your need. For example, to override return value of `toDataURL`:

--- a/__tests__/classes/CanvasRenderingContext2D.__clearDrawCalls.js
+++ b/__tests__/classes/CanvasRenderingContext2D.__clearDrawCalls.js
@@ -14,11 +14,11 @@ describe('__clearDrawCalls', () => {
   it("should clear the list of draw calls", () => {
     ctx.fillRect(1, 2, 3, 4);
     ctx.__clearDrawCalls();
-  })
+  });
 
   it("should not prevent additional draw calls from being collected", () => {
     ctx.fillRect(1, 2, 3, 4);
     ctx.__clearDrawCalls();
     ctx.fillRect(1, 2, 3, 4);
-  })
-})
+  });
+});

--- a/__tests__/classes/CanvasRenderingContext2D.__clearDrawCalls.js
+++ b/__tests__/classes/CanvasRenderingContext2D.__clearDrawCalls.js
@@ -1,0 +1,24 @@
+let ctx;
+beforeEach(() => {
+  // get a new context each test
+  ctx = document.createElement('canvas')
+    .getContext('2d');
+});
+
+afterEach(() => {
+  const drawCalls = ctx.__getDrawCalls();
+  expect(drawCalls).toMatchSnapshot();
+});
+
+describe('__clearDrawCalls', () => {
+  it("should clear the list of draw calls", () => {
+    ctx.fillRect(1, 2, 3, 4);
+    ctx.__clearDrawCalls();
+  })
+
+  it("should not prevent additional draw calls from being collected", () => {
+    ctx.fillRect(1, 2, 3, 4);
+    ctx.__clearDrawCalls();
+    ctx.fillRect(1, 2, 3, 4);
+  })
+})

--- a/__tests__/classes/CanvasRenderingContext2D.__clearEvents.js
+++ b/__tests__/classes/CanvasRenderingContext2D.__clearEvents.js
@@ -1,0 +1,24 @@
+let ctx;
+beforeEach(() => {
+  // get a new context each test
+  ctx = document.createElement('canvas')
+    .getContext('2d');
+});
+
+afterEach(() => {
+  const events = ctx.__getEvents();
+  expect(events).toMatchSnapshot();
+});
+
+describe('__clearEvents', () => {
+  it("should clear the list of events", () => {
+    ctx.fillRect(1, 2, 3, 4);
+    ctx.__clearEvents();
+  })
+
+  it("should not prevent additional events from being collected", () => {
+    ctx.fillRect(1, 2, 3, 4);
+    ctx.__clearEvents();
+    ctx.fillRect(1, 2, 3, 4);
+  })
+})

--- a/__tests__/classes/CanvasRenderingContext2D.__clearPath.js
+++ b/__tests__/classes/CanvasRenderingContext2D.__clearPath.js
@@ -6,19 +6,19 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  const events = ctx.__getEvents();
+  const events = ctx.__getPath();
   expect(events).toMatchSnapshot();
 });
 
 describe('__clearEvents', () => {
   it("should clear the list of events", () => {
-    ctx.fillRect(1, 2, 3, 4);
-    ctx.__clearEvents();
+    ctx.arc(1, 2, 3, 4, 5);
+    ctx.__clearPath();
   });
 
   it("should not prevent additional events from being collected", () => {
-    ctx.fillRect(1, 2, 3, 4);
-    ctx.__clearEvents();
-    ctx.fillRect(1, 2, 3, 4);
+    ctx.arc(1, 2, 3, 4, 5);
+    ctx.__clearPath();
+    ctx.arc(1, 2, 3, 4, 5);
   });
 });

--- a/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__clearDrawCalls.js.snap
+++ b/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__clearDrawCalls.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`__clearDrawCalls should clear the list of draw calls 1`] = `Array []`;
+
+exports[`__clearDrawCalls should not prevent additional draw calls from being collected 1`] = `
+Array [
+  Object {
+    "props": Object {
+      "height": 4,
+      "width": 3,
+      "x": 1,
+      "y": 2,
+    },
+    "transform": Array [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillRect",
+  },
+]
+`;

--- a/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__clearEvents.js.snap
+++ b/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__clearEvents.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`__clearEvents should clear the list of events 1`] = `Array []`;
+
+exports[`__clearEvents should not prevent additional events from being collected 1`] = `
+Array [
+  Object {
+    "props": Object {
+      "height": 4,
+      "width": 3,
+      "x": 1,
+      "y": 2,
+    },
+    "transform": Array [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillRect",
+  },
+]
+`;

--- a/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__clearPath.js.snap
+++ b/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__clearPath.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`__clearEvents should clear the list of events 1`] = `
+Array [
+  Object {
+    "props": Object {},
+    "transform": Array [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+]
+`;
+
+exports[`__clearEvents should not prevent additional events from being collected 1`] = `
+Array [
+  Object {
+    "props": Object {},
+    "transform": Array [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  Object {
+    "props": Object {
+      "anticlockwise": false,
+      "endAngle": 5,
+      "radius": 3,
+      "startAngle": 4,
+      "x": 1,
+      "y": 2,
+    },
+    "transform": Array [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "arc",
+  },
+]
+`;

--- a/package.json
+++ b/package.json
@@ -15,17 +15,17 @@
     "parse-color": "^1.0.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.4.4",
-    "@babel/core": "^7.4.4",
-    "@babel/plugin-proposal-class-properties": "^7.4.4",
-    "@babel/preset-env": "^7.4.4",
-    "@commitlint/cli": "^7.5.2",
-    "@commitlint/config-angular": "^7.5.0",
-    "babel-jest": "^24.8.0",
+    "@babel/cli": "^7.6.4",
+    "@babel/core": "^7.6.4",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/preset-env": "^7.6.3",
+    "@commitlint/cli": "^8.2.0",
+    "@commitlint/config-angular": "^8.2.0",
+    "babel-jest": "^24.9.0",
     "babel-plugin-version": "^0.2.3",
-    "coveralls": "^3.0.3",
-    "husky": "^2.2.0",
-    "jest": "^24.8.0"
+    "coveralls": "^3.0.7",
+    "husky": "^3.0.9",
+    "jest": "^24.9.0"
   },
   "commitlint": {
     "extends": [

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -43,12 +43,26 @@ export default class CanvasRenderingContext2D {
   }
 
   /**
+   * Clear the list of draw calls
+   */
+  __clearDrawCalls() {
+    this._drawCalls = []
+  }
+
+  /**
    * Every time a function call results in something that would have modified the state of the context,
    * an event is added to this array. This goes for every property set, and draw call.
    */
   _events = [];
   __getEvents() {
     return this._events.slice();
+  }
+
+  /**
+   * Clear the list of events
+   */
+  __clearEvents() {
+    this._events = [];
   }
 
   /**

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -74,6 +74,18 @@ export default class CanvasRenderingContext2D {
     return this._path.slice();
   }
 
+  /**
+   * Clear the path and reset it to a single beginPath event.
+   */
+  __clearPath() {
+    const event = createCanvasEvent(
+      'beginPath',
+      getTransformSlice(this),
+      { },
+    );
+    this._path = [event];
+  }
+
   _directionStack = ['inherit'];
   _fillStyleStack = ['#000'];
   _filterStack = ['none'];
@@ -173,13 +185,9 @@ export default class CanvasRenderingContext2D {
   }
 
   beginPath() {
-    const event = createCanvasEvent(
-      'beginPath',
-      getTransformSlice(this),
-      { },
-    );
-    this._path = [event];
-    this._events.push(event);
+    this.__clearPath();
+    // push the generated beginPath to the event list
+    this._events.push(this._path[0]);
   }
 
   bezierCurveTo(cpx1, cpy1, cpx2, cpy2, x, y) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,6 +30,18 @@ declare global {
     __getEvents(): CanvasRenderingContext2DEvent[];
 
     /**
+     * Clear all the events associated with this CanvasRenderingContext2D object.
+     *
+     * This method cannot be used in a production environment, only with `jest` using
+     * `jest-canvas-mock` and should only be used for testing.
+     *
+     * @example
+     * ctx.__clearEvents());
+     * expect(ctx.__getEvents()).toBe([]);
+     */
+    __clearEvents(): void;
+
+    /**
      * Get all the successful draw calls associated with this CanvasRenderingContext2D object.
      *
      * This method cannot be used in a production environment, only with `jest` using
@@ -39,6 +51,18 @@ declare global {
      * expect(ctx.__getDrawCalls()).toMatchSnapshot();
      */
     __getDrawCalls(): CanvasRenderingContext2DEvent[];
+
+    /**
+     * Clear all the successful draw calls associated with this CanvasRenderingContext2D object.
+     *
+     * This method cannot be used in a production environment, only with `jest` using
+     * `jest-canvas-mock` and should only be used for testing.
+     *
+     * @example
+     * ctx.__clearDrawCalls());
+     * expect(ctx.__getDrawCalls()).toBe([]);
+     */
+    __clearDrawCalls(): void;
 
     /**
      * Get the current path associated with this CanvasRenderingContext2D object.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -74,5 +74,13 @@ declare global {
      * expect(ctx.__getPath()).toMatchSnapshot();
      */
     __getPath(): CanvasRenderingContext2DEvent[];
+
+    /**
+     * Clears the current path associated with this CanvasRenderingContext2D object.
+     *
+     * This method cannot be used in a production environment, only with `jest` using
+     * `jest-canvas-mock` and should be only used for testing.
+     */
+    __clearPath(): void;
   }
 }


### PR DESCRIPTION
* Adds __clearDrawCalls for clearing draw calls
* Adds __clearEvents for clearing events
* Updates README to mention the new functions
* Adds TypeScript definitions for __clearDrawCalls and __clearEvents

Closes #48.

I decided not to add `__clearPath` as that is cleared for every `beginPath` call already.

I have never used TypeScript, so the definitions are a bit of a guess.