### PR TITLE
fix(transform): slice transform on save, node 13

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,13 @@
 {
-  "presets": ["@babel/env"],
+  "presets": [
+    [
+      "@babel/env",
+      {
+        "targets": {
+          "node": "8"
+        }
+      }
+    ]
+  ],
   "plugins": ["@babel/proposal-class-properties", "version"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 node_js:
-    - "6"
-    - "7"
     - "8"
     - "9"
     - "10"
     - "11"
     - "12"
+    - "13"
 after_success:
     - npm run coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # CHANGELOG
 
-# Version 2.1.1
+## Version 2.2.0
 
-- Feature: Support for ImageData instantiation using a source array(#45)
+- Bug: Slice canvas transform value when pushing (#50)
+- Remove support for node 6 and 7
+- switch babel env to target node 8
+- add support for node 13
+- update package versions
 
-# Version 2.1.0
+## Version 2.1.1
+
+- Feature: Support for ImageData instantiation using a source array (#45)
+
+## Version 2.1.0
 
 This minor version bump now has some major snapshot support but is backwards compatible.
 
@@ -29,13 +37,13 @@ Changes:
 - Feature: Add `_path` and `_events` to `Path2D`
 - Testing: Add and test snapshot outputs
 
-# Version 2.0.0
+## Version 2.0.0
 
 Just publish a stable version.
 
-# Version 2.0.0-beta.1
+## Version 2.0.0-beta.1
 
-## Class Instances
+### Class Instances
 
 The Version 2.0.0-beta.1 of `jest-canvas-mock` is a complete overhaul of the mocking strategy entirely. Originally, the `canvas.getCanvas('2d')` method would return a single object that contained a set of methods without any property definitions. This caused problems for people who wanted to use `jest` to test and verify `instanceof` checks.
 
@@ -47,7 +55,7 @@ const ctx = document.createElement('canvas').getContext('2d');
 expect(ctx).toBeInstanceOf(CanvasRenderingContext2D);
 ```
 
-## Bound Mock Functions
+### Bound Mock Functions
 
 When each `CanvasRenderingContext2D` object is created, all the methods are properly mocked with the `jest.fn()` method, and bound to the instance. It's still possible to verify that a function was called on the context. The main difference now is that the methods actually perform runtime checks on the passed parameters.
 
@@ -64,7 +72,7 @@ expect(ctx.arc).toBeCalledWith(0, 0, 100, 0, PI_2);
 expect(() => ctx.arc(0, 0, -10, 0, PI_2)).toThrow(DOMExpection);
 ```
 
-# Parsing Colors and Fonts, Saving, Restoring
+### Parsing Colors and Fonts, Saving, Restoring
 
 Another really big change is that the mocking strategy now attempts to conform to the html living specification. In order to do this, two packages were added as dependencies so that css colors and fonts can be more properly parsed. This is not perfect, and any problems with the color parser or font parser should be reported in the Issues tab.
 
@@ -99,7 +107,7 @@ expect(ctx.font).toBe('10px sans-serif');
 
 For all these reasons, the `jest-canvas-mock` package was bumped a major version to `2.0.0`.
 
-## CanvasRenderingContext2D prototype
+### CanvasRenderingContext2D prototype
 
 - Implemented Stack Properties for the following items:
   - `direction`
@@ -371,7 +379,7 @@ For all these reasons, the `jest-canvas-mock` package was bumped a major version
   - throws `TypeError` if `arguments.length < 2`
   - performs a translate operation on the current `transform` stack value if every parameter is finite
 
-## Other Changes By File
+### Other Changes By File
 
 - src/CanvasGradient.js
   - Added Class for `instanceof` checks
@@ -452,4 +460,3 @@ For all these reasons, the `jest-canvas-mock` package was bumped a major version
     - This function cannot normally be constructed
     - mocked to accept a `text` parameter
     - sets `width` property to `text.length`
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - switch babel env to target node 8
 - add support for node 13
 - update package versions
+- fix lineWidth bug
 
 ## Version 2.1.1
 

--- a/__tests__/classes/CanvasRenderingContext2D.lineWidth.js
+++ b/__tests__/classes/CanvasRenderingContext2D.lineWidth.js
@@ -39,6 +39,10 @@ describe('lineWidth', () => {
     ctx.save();
     ctx.lineWidth = 10;
     expect(ctx.lineWidth).toBe(10);
+    ctx.save();
+    expect(ctx.lineWidth).toBe(10);
+    ctx.restore();
+    expect(ctx.lineWidth).toBe(10);
     ctx.restore();
     expect(ctx.lineWidth).toBe(2);
   });

--- a/package.json
+++ b/package.json
@@ -15,17 +15,17 @@
     "parse-color": "^1.0.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.4.4",
-    "@babel/core": "^7.4.4",
-    "@babel/plugin-proposal-class-properties": "^7.4.4",
-    "@babel/preset-env": "^7.4.4",
-    "@commitlint/cli": "^7.5.2",
-    "@commitlint/config-angular": "^7.5.0",
-    "babel-jest": "^24.8.0",
+    "@babel/cli": "^7.6.4",
+    "@babel/core": "^7.6.4",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/preset-env": "^7.6.3",
+    "@commitlint/cli": "^8.2.0",
+    "@commitlint/config-angular": "^8.2.0",
+    "babel-jest": "^24.9.0",
     "babel-plugin-version": "^0.2.3",
-    "coveralls": "^3.0.3",
-    "husky": "^2.2.0",
-    "jest": "^24.8.0"
+    "coveralls": "^3.0.7",
+    "husky": "^3.0.9",
+    "jest": "^24.9.0"
   },
   "commitlint": {
     "extends": [

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -1091,7 +1091,7 @@ export default class CanvasRenderingContext2D {
     this._lineDashStack.push(this._lineDashStack[this._stackIndex]);
     this._lineDashOffsetStack.push(this._lineDashOffsetStack[this._stackIndex]);
     this._lineJoinStack.push(this._lineJoinStack[this._stackIndex]);
-    this._lineWidthStack.push(this._lineWidthStack[this.stackIndex]);
+    this._lineWidthStack.push(this._lineWidthStack[this._stackIndex]);
     this._miterLimitStack.push(this._miterLimitStack[this._stackIndex]);
     this._shadowBlurStack.push(this._shadowBlurStack[this._stackIndex]);
     this._shadowColorStack.push(this._shadowColorStack[this._stackIndex]);

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -1078,7 +1078,7 @@ export default class CanvasRenderingContext2D {
   }
 
   save() {
-    this._transformStack.push(this._transformStack[this._stackIndex]);
+    this._transformStack.push(this._transformStack[this._stackIndex].slice());
     this._directionStack.push(this._directionStack[this._stackIndex]);
     this._fillStyleStack.push(this._fillStyleStack[this._stackIndex]);
     this._filterStack.push(this._filterStack[this._stackIndex]);


### PR DESCRIPTION
Apparently I don't have write access to the repo, but that's fine. I can submit pull requests like this.

Changes:

- Add support for node 13
- remove support for node 6 and 7
- add slice to transform push (adds more memory usage but is compliant with spec
- update babel env to target node 8
- update node packages
- cleanup changelog docs

Please check my work and publish at your convenience.

I didn't include the version bump to 2.2.0, but you should definitely do this when you're ready.

Fixes: #50 
Fixes: #53 