### PR TITLE
fix(gradients): support for 'transparent' as a color stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Version 2.3.0
+
+- Switched to `moo-color` for color parsing
+- Added contributors to markdown document
+
 ## Version 2.2.0
 
 - Bug: Slice canvas transform value when pushing (#50)

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ canvas.toDataURL.mockReturnValueOnce(
 );
 ```
 
+## Contributors
+
+* [@hustcc](https://github.com/hustcc)
+* [@jtenner](https://github.com/jtenner)
+* [@evanoc0](https://github.com/evanoc0)
+
 ## License
 
 MIT@[hustcc](https://github.com/hustcc).

--- a/__tests__/classes/CanvasGradient.js
+++ b/__tests__/classes/CanvasGradient.js
@@ -26,7 +26,7 @@ describe('CanvasGradient', () => {
     test('CanvasGradient should throw if offset is ' + value, () => {
       expect(() => {
         var grd = ctx.createLinearGradient(1, 2, 3, 4);
-        grd.addColorStop(value, "blue");
+        grd.addColorStop(value, 'blue');
       }).toThrow(DOMException);
     });
   });
@@ -50,15 +50,15 @@ describe('CanvasGradient', () => {
   test('CanvasGradient should throw if color cannot be parsed', () => {
     const grd = ctx.createLinearGradient(1, 2, 3, 4);
     expect(() => {
-      grd.addColorStop(0.5, "invalid");
+      grd.addColorStop(0.5, 'invalid');
     }).toThrow(SyntaxError);
 
     expect(() => {
-      grd.addColorStop(0.5, "rgb(50%, 0, 50%)");
+      grd.addColorStop(0.5, 'rgb(50%, 0, 50%)');
     }).toThrow(SyntaxError);
 
     expect(() => {
-      grd.addColorStop(0.5, "hsl(180, 50%, 50)");
+      grd.addColorStop(0.5, 'hsl(180, 50%, 50)');
     }).toThrow(SyntaxError);
   });
 });

--- a/__tests__/classes/CanvasGradient.js
+++ b/__tests__/classes/CanvasGradient.js
@@ -31,26 +31,34 @@ describe('CanvasGradient', () => {
     });
   });
 
-  test('CanvasGradient should throw if color cannot be parsed', () => {
-    expect(() => {
-      var grd = ctx.createLinearGradient(1, 2, 3, 4);
-      grd.addColorStop(1, "badcolor");
-    }).toThrow(SyntaxError);
-  });
-
   test('should accept all valid CSS colors as a color stop', () => {
-    const grd = ctx.createLinearGradient(0, 0, 0, 0);
+    const grd = ctx.createLinearGradient(0, 0, 100, 100);
     expect(() => {
-      grd.addColorStop(0.0, 'transparent');
-      grd.addColorStop(0.1, 'pink');
-      grd.addColorStop(0.2, '#ff0000');
+      grd.addColorStop(0.1, 'blue');
+      grd.addColorStop(0.2, '#f008');
+      grd.addColorStop(0.2, '#f0f0f0');
+      grd.addColorStop(0.3, '#f0f0f0f0');
       grd.addColorStop(0.3, 'rgb(10, 10, 10)');
-      grd.addColorStop(0.4, 'hsl(0, 100%, 50%)');
+      grd.addColorStop(0.4, 'rgb(100%, 25%, 25%)');
+      grd.addColorStop(0.3, 'rgba(100, 100, 100, 0.5)');
+      grd.addColorStop(0.4, 'hsl(180, 100%, 50%)');
+      grd.addColorStop(0.5, 'hsla(180, 100%, 50%, 0.5)');
+      grd.addColorStop(0.0, 'transparent');
     }).not.toThrow(SyntaxError);
   });
 
-  test('should not accept an invalid CSS color as a color stop', () => {
-    const grd = ctx.createLinearGradient(0, 0, 0, 0);
-    expect(() => grd.addColorStop(0.5, "invalid")).toThrow(SyntaxError);
+  test('CanvasGradient should throw if color cannot be parsed', () => {
+    const grd = ctx.createLinearGradient(1, 2, 3, 4);
+    expect(() => {
+      grd.addColorStop(0.5, "invalid");
+    }).toThrow(SyntaxError);
+
+    expect(() => {
+      grd.addColorStop(0.5, "rgb(50%, 0, 50%)");
+    }).toThrow(SyntaxError);
+
+    expect(() => {
+      grd.addColorStop(0.5, "hsl(180, 50%, 50)");
+    }).toThrow(SyntaxError);
   });
 });

--- a/__tests__/classes/CanvasGradient.js
+++ b/__tests__/classes/CanvasGradient.js
@@ -37,4 +37,20 @@ describe('CanvasGradient', () => {
       grd.addColorStop(1, "badcolor");
     }).toThrow(SyntaxError);
   });
+
+  test('should accept all valid CSS colors as a color stop', () => {
+    const grd = ctx.createLinearGradient(0, 0, 0, 0);
+    expect(() => {
+      grd.addColorStop(0.0, 'transparent');
+      grd.addColorStop(0.1, 'pink');
+      grd.addColorStop(0.2, '#ff0000');
+      grd.addColorStop(0.3, 'rgb(10, 10, 10)');
+      grd.addColorStop(0.4, 'hsl(0, 100%, 50%)');
+    }).not.toThrow(SyntaxError);
+  });
+
+  test('should not accept an invalid CSS color as a color stop', () => {
+    const grd = ctx.createLinearGradient(0, 0, 0, 0);
+    expect(() => grd.addColorStop(0.5, "invalid")).toThrow(SyntaxError);
+  });
 });

--- a/__tests__/classes/CanvasRenderingContext2D.fillStyle.js
+++ b/__tests__/classes/CanvasRenderingContext2D.fillStyle.js
@@ -11,7 +11,7 @@ beforeEach(() => {
 describe('fillStyle', () => {
   it('should parse a css color string \'blue\'', () => {
     ctx.fillStyle = 'blue';
-    expect(ctx.fillStyle).toBe('#00f');
+    expect(ctx.fillStyle).toBe('blue');
   });
 
   it('should not parse invalid colors', () => {
@@ -28,9 +28,9 @@ describe('fillStyle', () => {
     ctx.fillStyle = 'green';
     ctx.save();
     ctx.fillStyle = 'red';
-    expect(ctx.fillStyle).toBe('#f00');
+    expect(ctx.fillStyle).toBe('red');
     ctx.restore();
-    expect(ctx.fillStyle).toBe('#008000');
+    expect(ctx.fillStyle).toBe('green');
   });
 
   it('should accept CanvasPatterns as valid fillStyle values', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.fillStyle.js
+++ b/__tests__/classes/CanvasRenderingContext2D.fillStyle.js
@@ -11,12 +11,12 @@ beforeEach(() => {
 describe('fillStyle', () => {
   it('should parse a css color string \'blue\'', () => {
     ctx.fillStyle = 'blue';
-    expect(ctx.fillStyle).toBe('blue');
+    expect(ctx.fillStyle).toBe('#0000ff');
   });
 
   it('should not parse invalid colors', () => {
     ctx.fillStyle = 'invalid!';
-    expect(ctx.fillStyle).toBe('#000');
+    expect(ctx.fillStyle).toBe('#000000');
   });
 
   it('should parse css colors with alpha values', () => {
@@ -28,9 +28,9 @@ describe('fillStyle', () => {
     ctx.fillStyle = 'green';
     ctx.save();
     ctx.fillStyle = 'red';
-    expect(ctx.fillStyle).toBe('red');
+    expect(ctx.fillStyle).toBe('#ff0000');
     ctx.restore();
-    expect(ctx.fillStyle).toBe('green');
+    expect(ctx.fillStyle).toBe('#008000');
   });
 
   it('should accept CanvasPatterns as valid fillStyle values', () => {
@@ -49,6 +49,6 @@ describe('fillStyle', () => {
 
   it('should ignore invalid fillStyle values', () => {
     ctx.fillStyle = null;
-    expect(ctx.fillStyle).toBe('#000');
+    expect(ctx.fillStyle).toBe('#000000');
   });
 });

--- a/__tests__/classes/CanvasRenderingContext2D.shadowColor.js
+++ b/__tests__/classes/CanvasRenderingContext2D.shadowColor.js
@@ -11,7 +11,7 @@ beforeEach(() => {
 describe('shadowColor', () => {
   it('should parse a css color string \'blue\'', () => {
     ctx.shadowColor = 'blue';
-    expect(ctx.shadowColor).toBe('blue');
+    expect(ctx.shadowColor).toBe('#0000ff');
   });
 
   it('should not parse invalid colors', () => {
@@ -28,9 +28,9 @@ describe('shadowColor', () => {
     ctx.shadowColor = 'green';
     ctx.save();
     ctx.shadowColor = 'red';
-    expect(ctx.shadowColor).toBe('red');
+    expect(ctx.shadowColor).toBe('#ff0000');
     ctx.restore();
-    expect(ctx.shadowColor).toBe('green');
+    expect(ctx.shadowColor).toBe('#008000');
   });
 
   it('should ignore invalid shadowColor values', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.shadowColor.js
+++ b/__tests__/classes/CanvasRenderingContext2D.shadowColor.js
@@ -11,7 +11,7 @@ beforeEach(() => {
 describe('shadowColor', () => {
   it('should parse a css color string \'blue\'', () => {
     ctx.shadowColor = 'blue';
-    expect(ctx.shadowColor).toBe('#00f');
+    expect(ctx.shadowColor).toBe('blue');
   });
 
   it('should not parse invalid colors', () => {
@@ -28,9 +28,9 @@ describe('shadowColor', () => {
     ctx.shadowColor = 'green';
     ctx.save();
     ctx.shadowColor = 'red';
-    expect(ctx.shadowColor).toBe('#f00');
+    expect(ctx.shadowColor).toBe('red');
     ctx.restore();
-    expect(ctx.shadowColor).toBe('#008000');
+    expect(ctx.shadowColor).toBe('green');
   });
 
   it('should ignore invalid shadowColor values', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.strokeStyle.js
+++ b/__tests__/classes/CanvasRenderingContext2D.strokeStyle.js
@@ -11,7 +11,7 @@ beforeEach(() => {
 describe('strokeStyle', () => {
   it('should parse a css color string \'blue\'', () => {
     ctx.strokeStyle = 'blue';
-    expect(ctx.strokeStyle).toBe('#00f');
+    expect(ctx.strokeStyle).toBe('blue');
   });
 
   it('should not parse invalid colors', () => {
@@ -28,9 +28,9 @@ describe('strokeStyle', () => {
     ctx.strokeStyle = 'green';
     ctx.save();
     ctx.strokeStyle = 'red';
-    expect(ctx.strokeStyle).toBe('#f00');
+    expect(ctx.strokeStyle).toBe('red');
     ctx.restore();
-    expect(ctx.strokeStyle).toBe('#008000');
+    expect(ctx.strokeStyle).toBe('green');
   });
 
   it('should accept CanvasPatterns as valid strokeStyle values', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.strokeStyle.js
+++ b/__tests__/classes/CanvasRenderingContext2D.strokeStyle.js
@@ -11,12 +11,12 @@ beforeEach(() => {
 describe('strokeStyle', () => {
   it('should parse a css color string \'blue\'', () => {
     ctx.strokeStyle = 'blue';
-    expect(ctx.strokeStyle).toBe('blue');
+    expect(ctx.strokeStyle).toBe('#0000ff');
   });
 
   it('should not parse invalid colors', () => {
     ctx.strokeStyle = 'invalid!';
-    expect(ctx.strokeStyle).toBe('#000');
+    expect(ctx.strokeStyle).toBe('#000000');
   });
 
   it('should parse css colors with alpha values', () => {
@@ -28,9 +28,9 @@ describe('strokeStyle', () => {
     ctx.strokeStyle = 'green';
     ctx.save();
     ctx.strokeStyle = 'red';
-    expect(ctx.strokeStyle).toBe('red');
+    expect(ctx.strokeStyle).toBe('#ff0000');
     ctx.restore();
-    expect(ctx.strokeStyle).toBe('green');
+    expect(ctx.strokeStyle).toBe('#008000');
   });
 
   it('should accept CanvasPatterns as valid strokeStyle values', () => {
@@ -49,6 +49,6 @@ describe('strokeStyle', () => {
 
   it('should ignore invalid strokeStyle values', () => {
     ctx.strokeStyle = null;
-    expect(ctx.strokeStyle).toBe('#000');
+    expect(ctx.strokeStyle).toBe('#000000');
   });
 });

--- a/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
+++ b/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
@@ -1010,18 +1010,7 @@ exports[`__getEvents should have an event when fillStyle is set 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": MooColor {
-        "color": Object {
-          "alpha": 1,
-          "model": "rgb",
-          "values": Array [
-            0,
-            0,
-            255,
-          ],
-        },
-        "resolveHwb": [Function],
-      },
+      "value": "#0000ff",
     },
     "transform": Array [
       1,
@@ -1885,18 +1874,7 @@ exports[`__getEvents should have an event when the shadowColor is valid 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": MooColor {
-        "color": Object {
-          "alpha": 1,
-          "model": "rgb",
-          "values": Array [
-            255,
-            0,
-            0,
-          ],
-        },
-        "resolveHwb": [Function],
-      },
+      "value": "#ff0000",
     },
     "transform": Array [
       1,
@@ -1953,18 +1931,7 @@ exports[`__getEvents should have an event when the strokeStyle is set 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": MooColor {
-        "color": Object {
-          "alpha": 1,
-          "model": "rgb",
-          "values": Array [
-            0,
-            0,
-            255,
-          ],
-        },
-        "resolveHwb": [Function],
-      },
+      "value": "#0000ff",
     },
     "transform": Array [
       1,

--- a/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
+++ b/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
@@ -1010,7 +1010,7 @@ exports[`__getEvents should have an event when fillStyle is set 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": "#00f",
+      "value": "blue",
     },
     "transform": Array [
       1,
@@ -1874,7 +1874,7 @@ exports[`__getEvents should have an event when the shadowColor is valid 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": "#f00",
+      "value": "red",
     },
     "transform": Array [
       1,
@@ -1931,7 +1931,7 @@ exports[`__getEvents should have an event when the strokeStyle is set 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": "#00f",
+      "value": "blue",
     },
     "transform": Array [
       1,

--- a/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
+++ b/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
@@ -1010,7 +1010,18 @@ exports[`__getEvents should have an event when fillStyle is set 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": "blue",
+      "value": MooColor {
+        "color": Object {
+          "alpha": 1,
+          "model": "rgb",
+          "values": Array [
+            0,
+            0,
+            255,
+          ],
+        },
+        "resolveHwb": [Function],
+      },
     },
     "transform": Array [
       1,
@@ -1874,7 +1885,18 @@ exports[`__getEvents should have an event when the shadowColor is valid 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": "red",
+      "value": MooColor {
+        "color": Object {
+          "alpha": 1,
+          "model": "rgb",
+          "values": Array [
+            255,
+            0,
+            0,
+          ],
+        },
+        "resolveHwb": [Function],
+      },
     },
     "transform": Array [
       1,
@@ -1931,7 +1953,18 @@ exports[`__getEvents should have an event when the strokeStyle is set 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": "blue",
+      "value": MooColor {
+        "color": Object {
+          "alpha": 1,
+          "model": "rgb",
+          "values": Array [
+            0,
+            0,
+            255,
+          ],
+        },
+        "resolveHwb": [Function],
+      },
     },
     "transform": Array [
       1,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "cssfontparser": "^1.2.1",
-    "validate-color": "^1.0.6"
+    "moo-color": "^1.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "cssfontparser": "^1.2.1",
-    "parse-color": "^1.0.0"
+    "validate-color": "^1.0.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",

--- a/src/classes/CanvasGradient.js
+++ b/src/classes/CanvasGradient.js
@@ -1,4 +1,4 @@
-import validateColor from 'validate-color';
+import { MooColor } from "moo-color";
 
 export default class CanvasGradient {
   constructor() {
@@ -10,8 +10,10 @@ export default class CanvasGradient {
     if (!Number.isFinite(numoffset) || numoffset < 0 || numoffset > 1) {
       throw new DOMException('IndexSizeError', 'Failed to execute \'addColorStop\' on \'CanvasGradient\': The provided value (\'' + numoffset + '\') is outside the range (0.0, 1.0)');
     }
-    if (!validateColor(color)) {
-      throw new SyntaxError('Failed to execute \'addColorStop\' on \'CanvasGradient\': The value provided (\'' + color + '\') could not be parsed as a color.')
+    try {
+      new MooColor(color);
+    } catch(e) {
+      throw new SyntaxError('Failed to execute \'addColorStop\' on \'CanvasGradient\': The value provided (\'' + color + '\') could not be parsed as a color.');
     }
   }
 }

--- a/src/classes/CanvasGradient.js
+++ b/src/classes/CanvasGradient.js
@@ -11,7 +11,7 @@ export default class CanvasGradient {
       throw new DOMException('IndexSizeError', 'Failed to execute \'addColorStop\' on \'CanvasGradient\': The provided value (\'' + numoffset + '\') is outside the range (0.0, 1.0)');
     }
     const output = parseColor(colorstr);
-    if (!output.hex) {
+    if (!output.hex && output.keyword !== "transparent") {
       throw new SyntaxError('Failed to execute \'addColorStop\' on \'CanvasGradient\': The value provided (\'' + color + '\') could not be parsed as a color.')
     }
   }

--- a/src/classes/CanvasGradient.js
+++ b/src/classes/CanvasGradient.js
@@ -1,4 +1,4 @@
-import { MooColor } from "moo-color";
+import { MooColor } from 'moo-color';
 
 export default class CanvasGradient {
   constructor() {

--- a/src/classes/CanvasGradient.js
+++ b/src/classes/CanvasGradient.js
@@ -1,17 +1,16 @@
-import parseColor from 'parse-color';
+import validateColor from 'validate-color';
 
 export default class CanvasGradient {
   constructor() {
     this.addColorStop = jest.fn(this.addColorStop.bind(this));
   }
+
   addColorStop(offset, color) {
     const numoffset = Number(offset);
-    const colorstr = String(color);
     if (!Number.isFinite(numoffset) || numoffset < 0 || numoffset > 1) {
       throw new DOMException('IndexSizeError', 'Failed to execute \'addColorStop\' on \'CanvasGradient\': The provided value (\'' + numoffset + '\') is outside the range (0.0, 1.0)');
     }
-    const output = parseColor(colorstr);
-    if (!output.hex && output.keyword !== "transparent") {
+    if (!validateColor(color)) {
       throw new SyntaxError('Failed to execute \'addColorStop\' on \'CanvasGradient\': The value provided (\'' + color + '\') could not be parsed as a color.')
     }
   }

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -4,7 +4,7 @@ import cssfontparser from 'cssfontparser';
 import TextMetrics from './TextMetrics';
 import createCanvasEvent from '../mock/createCanvasEvent';
 import Path2D from "./Path2D";
-import { MooColor } from "moo-color";
+import { MooColor } from 'moo-color';
 
 
 const testFuncs = ['setLineDash', 'getLineDash', 'setTransform', 'getTransform', 'getImageData', 'save', 'restore', 'createPattern', 'createRadialGradient', 'addHitRegion', 'arc', 'arcTo', 'beginPath', 'clip', 'closePath', 'scale', 'stroke', 'clearHitRegions', 'clearRect', 'fillRect', 'strokeRect', 'rect', 'resetTransform', 'translate', 'moveTo', 'lineTo', 'bezierCurveTo', 'createLinearGradient', 'ellipse', 'measureText', 'rotate', 'drawImage', 'drawFocusIfNeeded', 'isPointInPath', 'isPointInStroke', 'putImageData', 'strokeText', 'fillText', 'quadraticCurveTo', 'removeHitRegion', 'fill', 'transform', 'scrollPathIntoView', 'createImageData'];
@@ -12,6 +12,13 @@ const compositeOperations = ['source-over', 'source-in', 'source-out', 'source-a
 
 function getTransformSlice(ctx) {
   return ctx._transformStack[ctx._stackIndex].slice();
+}
+
+function serializeColor(value) {
+  const mooColor = new MooColor(value);
+  return (mooColor.getAlpha() === 1)
+    ? mooColor.toHex()
+    : mooColor.toRgb();
 }
 
 export default class CanvasRenderingContext2D {
@@ -78,7 +85,7 @@ export default class CanvasRenderingContext2D {
   }
 
   _directionStack = ['inherit'];
-  _fillStyleStack = [ new MooColor("#000") ];
+  _fillStyleStack = [ '#000000' ];
   _filterStack = ['none'];
   _fontStack = ['10px sans-serif'];
   _globalAlphaStack = [1.0];
@@ -92,11 +99,11 @@ export default class CanvasRenderingContext2D {
   _lineWidthStack = [1];
   _miterLimitStack = [10];
   _shadowBlurStack = [0];
-  _shadowColorStack = [ new MooColor("rgba(0,0,0,0)") ];
+  _shadowColorStack = [ 'rgba(0, 0, 0, 0)' ];
   _shadowOffsetXStack = [0];
   _shadowOffsetYStack = [0];
   _stackIndex = 0;
-  _strokeStyleStack = [ new MooColor("#000") ];
+  _strokeStyleStack = [ '#000000' ];
   _textAlignStack = ['start'];
   _textBaselineStack = ['alphabetic'];
   _transformStack = [[1, 0, 0, 1, 0, 0]];
@@ -619,9 +626,9 @@ export default class CanvasRenderingContext2D {
     let valid = false;
     if (typeof value === 'string') {
       try {
-        value = new MooColor(value);
+        const result = new MooColor(value);
         valid = true;
-        this._fillStyleStack[this._stackIndex] = value;
+        value = this._fillStyleStack[this._stackIndex] = result.toHex();
       }
       catch(e) { return; }
     }
@@ -641,12 +648,9 @@ export default class CanvasRenderingContext2D {
   }
 
   get fillStyle() {
-    let color = this._fillStyleStack[this._stackIndex];
-    if(color instanceof MooColor) {
-      if(color.getAlpha() == 1) {
-        return color.toHex();
-      }
-      return color.toRgb();
+    const color = this._fillStyleStack[this._stackIndex];
+    if(typeof color === 'string') {
+      return serializeColor(color);
     }
     return color;
   }
@@ -1272,8 +1276,8 @@ export default class CanvasRenderingContext2D {
   set shadowColor(value) {
     if (typeof value === 'string') {
       try { 
-        value = new MooColor(value);
-        this._shadowColorStack[this._stackIndex] = value;
+        const result = new MooColor(value);
+        value = this._shadowColorStack[this._stackIndex] = result.toHex();
       } catch (e) { return; }
 
       const event = createCanvasEvent(
@@ -1286,11 +1290,7 @@ export default class CanvasRenderingContext2D {
   }
 
   get shadowColor() {
-    const color = this._shadowColorStack[this._stackIndex];
-    if (color.getAlpha() === 1) {
-      return color.toHex();
-    }
-    return color.toRgb();
+    return serializeColor(this._shadowColorStack[this._stackIndex]);
   }
 
   set shadowOffsetX(value) {
@@ -1367,9 +1367,10 @@ export default class CanvasRenderingContext2D {
     let valid = false;
     if (typeof value === 'string') {
       try {
+        const colorObject = new MooColor(value);
         value = new MooColor(value);
         valid = true;
-        this._strokeStyleStack[this._stackIndex] = value;
+        value = this._strokeStyleStack[this._stackIndex] = colorObject.toHex();
       }
       catch(e) { return; }
     }
@@ -1389,13 +1390,9 @@ export default class CanvasRenderingContext2D {
   }
 
   get strokeStyle() {
-    let color = this._strokeStyleStack[this._stackIndex];
-    if (color instanceof MooColor) {
-      if (color.getAlpha() == 1) {
-        return color.toHex("full");
-      } else {
-        return color.toRgb();
-      }
+    const color = this._strokeStyleStack[this._stackIndex];
+    if (typeof color === 'string') {
+      return serializeColor(color)
     }
     return color;
   }

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -14,6 +14,9 @@ function getTransformSlice(ctx) {
   return ctx._transformStack[ctx._stackIndex].slice();
 }
 
+/**
+ * Returns the string serialization of a CSS color, according to https://www.w3.org/TR/2dcontext/#serialization-of-a-color
+ */
 function serializeColor(value) {
   return (value.getAlpha() === 1)
     ? value.toHex()

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -15,10 +15,9 @@ function getTransformSlice(ctx) {
 }
 
 function serializeColor(value) {
-  const mooColor = new MooColor(value);
-  return (mooColor.getAlpha() === 1)
-    ? mooColor.toHex()
-    : mooColor.toRgb();
+  return (value.getAlpha() === 1)
+    ? value.toHex()
+    : value.toRgb();
 }
 
 export default class CanvasRenderingContext2D {
@@ -628,7 +627,7 @@ export default class CanvasRenderingContext2D {
       try {
         const result = new MooColor(value);
         valid = true;
-        value = this._fillStyleStack[this._stackIndex] = result.toHex();
+        value = this._fillStyleStack[this._stackIndex] = serializeColor(result);
       }
       catch(e) { return; }
     }
@@ -648,11 +647,7 @@ export default class CanvasRenderingContext2D {
   }
 
   get fillStyle() {
-    const color = this._fillStyleStack[this._stackIndex];
-    if(typeof color === 'string') {
-      return serializeColor(color);
-    }
-    return color;
+    return this._fillStyleStack[this._stackIndex];
   }
 
   fillText(text, x, y, maxWidth) {
@@ -1277,7 +1272,7 @@ export default class CanvasRenderingContext2D {
     if (typeof value === 'string') {
       try { 
         const result = new MooColor(value);
-        value = this._shadowColorStack[this._stackIndex] = result.toHex();
+        value = this._shadowColorStack[this._stackIndex] = serializeColor(result);
       } catch (e) { return; }
 
       const event = createCanvasEvent(
@@ -1290,7 +1285,7 @@ export default class CanvasRenderingContext2D {
   }
 
   get shadowColor() {
-    return serializeColor(this._shadowColorStack[this._stackIndex]);
+    return this._shadowColorStack[this._stackIndex];
   }
 
   set shadowOffsetX(value) {
@@ -1367,10 +1362,9 @@ export default class CanvasRenderingContext2D {
     let valid = false;
     if (typeof value === 'string') {
       try {
-        const colorObject = new MooColor(value);
-        value = new MooColor(value);
+        const result = new MooColor(value);
         valid = true;
-        value = this._strokeStyleStack[this._stackIndex] = colorObject.toHex();
+        value = this._strokeStyleStack[this._stackIndex] = serializeColor(result);
       }
       catch(e) { return; }
     }
@@ -1390,11 +1384,7 @@ export default class CanvasRenderingContext2D {
   }
 
   get strokeStyle() {
-    const color = this._strokeStyleStack[this._stackIndex];
-    if (typeof color === 'string') {
-      return serializeColor(color)
-    }
-    return color;
+    return this._strokeStyleStack[this._stackIndex];
   }
 
   strokeText(text, x, y, maxWidth) {

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -1,30 +1,12 @@
 import DOMMatrix from './DOMMatrix';
 import CanvasPattern from './CanvasPattern';
-import parseColor from 'parse-color';
+import validateColor from 'validate-color';
 import cssfontparser from 'cssfontparser';
 import TextMetrics from './TextMetrics';
 import createCanvasEvent from '../mock/createCanvasEvent';
 import Path2D from "./Path2D";
 
-function parseCSSColor(value) {
-  const result = parseColor(value);
 
-  if (result.rgba && result.rgba[3] !== 1) {
-    return 'rgba(' + result.rgba.join(', ') + ')';
-  }
-
-  if (result.hex) {
-    const hex = result.hex;
-
-    // shorthand #ABC
-    if (hex[1] === hex[2] && hex[3] === hex[4] && hex[5] === hex[6]) {
-      return '#' + hex[1] + hex[3] + hex[5];
-    }
-    return result.hex;
-  }
-
-  return void 0;
-}
 
 const testFuncs = ['setLineDash', 'getLineDash', 'setTransform', 'getTransform', 'getImageData', 'save', 'restore', 'createPattern', 'createRadialGradient', 'addHitRegion', 'arc', 'arcTo', 'beginPath', 'clip', 'closePath', 'scale', 'stroke', 'clearHitRegions', 'clearRect', 'fillRect', 'strokeRect', 'rect', 'resetTransform', 'translate', 'moveTo', 'lineTo', 'bezierCurveTo', 'createLinearGradient', 'ellipse', 'measureText', 'rotate', 'drawImage', 'drawFocusIfNeeded', 'isPointInPath', 'isPointInStroke', 'putImageData', 'strokeText', 'fillText', 'quadraticCurveTo', 'removeHitRegion', 'fill', 'transform', 'scrollPathIntoView', 'createImageData'];
 const compositeOperations = ['source-over', 'source-in', 'source-out', 'source-atop', 'destination-over', 'destination-in', 'destination-out', 'destination-atop', 'lighter', 'copy', 'xor', 'multiply', 'screen', 'overlay', 'darken', 'lighten', 'color-dodge', 'color-burn', 'hard-light', 'soft-light', 'difference', 'exclusion', 'hue', 'saturation', 'color', 'luminosity'];
@@ -636,14 +618,7 @@ export default class CanvasRenderingContext2D {
 
   set fillStyle(value) {
     let valid = false;
-    if (typeof value === 'string') {
-      const result = parseCSSColor(value);
-
-      if (result) {
-        valid = true;
-        value = this._fillStyleStack[this._stackIndex] = result;
-      }
-    } else if (value instanceof CanvasGradient || value instanceof CanvasPattern) {
+    if ( (typeof value === 'string' && validateColor(value)) || value instanceof CanvasGradient || value instanceof CanvasPattern) {
       valid = true;
       this._fillStyleStack[this._stackIndex] = value;
     }
@@ -1281,18 +1256,14 @@ export default class CanvasRenderingContext2D {
   }
 
   set shadowColor(value) {
-    if (typeof value === 'string') {
-      const result = parseCSSColor(value);
-
-      if (result) {
-        this._shadowColorStack[this._stackIndex] = result;
-        const event = createCanvasEvent(
-          'shadowColor',
-          getTransformSlice(this),
-          { value: result },
-        );
-        this._events.push(event);
-      }
+    if (typeof value === 'string' && validateColor(value)) {
+      this._shadowColorStack[this._stackIndex] = value;
+      const event = createCanvasEvent(
+        'shadowColor',
+        getTransformSlice(this),
+        { value: value },
+      );
+      this._events.push(event);
     }
   }
 
@@ -1372,14 +1343,7 @@ export default class CanvasRenderingContext2D {
 
   set strokeStyle(value) {
     let valid = false;
-    if (typeof value === 'string') {
-      const result = parseCSSColor(value);
-
-      if (result) {
-        valid = true;
-        value = this._strokeStyleStack[this._stackIndex] = result;
-      }
-    } else if (value instanceof CanvasGradient || value instanceof CanvasPattern) {
+    if ( (typeof value === 'string' && validateColor(value)) || value instanceof CanvasGradient || value instanceof CanvasPattern) {
       valid = true;
       this._strokeStyleStack[this._stackIndex] = value;
     }


### PR DESCRIPTION
No other modules I found could be used _plug'n'play_ here. It seems that the only value that parse-color doesn't handle correctly is `transparent`, so it can be handled especially

Some test cases that verify different color formats get handled correctly wouldn't hurt either.

resolves #64 

