### PR TITLE
fix setLineDash parameter name: value -> segments

### DIFF
--- a/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
+++ b/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
@@ -1561,7 +1561,7 @@ exports[`__getEvents should have an event when setLineDash is called 1`] = `
 Array [
   Object {
     "props": Object {
-      "value": Array [
+      "segments": Array [
         1,
         2,
         3,

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -1639,7 +1639,7 @@ export default class CanvasRenderingContext2D {
     result = this._lineDashStack[this._stackIndex] =
       result.length % 2 === 1 ? result.concat(result) : result;
     const event = createCanvasEvent('setLineDash', getTransformSlice(this), {
-      value: result.slice(),
+      segments: result.slice(),
     });
     this._events.push(event);
   }


### PR DESCRIPTION
use the same parameter name as in `typescript/lib/lib.dom.d.ts`

```ts
interface CanvasPathDrawingStyles {
    // ....
    setLineDash(segments: number[]): void;
}
```
so we can auto-generate interfaces as shown [here](https://github.com/MrMaxie/ts-types-parser/pull/4)