### PR TITLE
fix(window): avoid `global.window` redefinition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: build
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Node.js ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 14
+          - 16
+          - 18
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - '12'
-  - '14'
-  - '16'
-  - 'node'
-after_success:
-  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Mock `canvas` when run unit test cases with jest. For more browser environment, you can use [jest-electron](https://github.com/hustcc/jest-electron) for real browser runtime.
 
-[![Build Status](https://travis-ci.org/hustcc/jest-canvas-mock.svg?branch=master)](https://travis-ci.org/hustcc/jest-canvas-mock)
+[![Build Status](https://github.com/hustcc/jest-canvas-mock/workflows/build/badge.svg)](https://github.com/hustcc/jest-canvas-mock/actions/workflows/build.yml)
 [![Coverage Status](https://coveralls.io/repos/github/hustcc/jest-canvas-mock/badge.svg?branch=master)](https://coveralls.io/github/hustcc/jest-canvas-mock)
 [![npm](https://img.shields.io/npm/v/jest-canvas-mock.svg)](https://www.npmjs.com/package/jest-canvas-mock)
 [![npm](https://img.shields.io/npm/dm/jest-canvas-mock.svg)](https://www.npmjs.com/package/jest-canvas-mock)

--- a/__mocks__/worker.js
+++ b/__mocks__/worker.js
@@ -1,0 +1,12 @@
+global.window.Worker = class {
+  constructor(stringUrl) {
+    this.url = stringUrl;
+    this.onmessage = () => {};
+  }
+
+  postMessage(msg) {
+    this.onmessage(msg);
+  }
+};
+
+global.window.URL.createObjectURL = jest.fn();

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "src/mock/**/*.js"
     ],
     "setupFiles": [
-      "./src/index.js"
+      "./src/index.js",
+      "./__mocks__/worker.js"
     ]
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import mockWindow from './window';
 // mock global window
 // TODO: Force coverage to ignore this branch
 if (typeof window !== 'undefined') {
-  global.window = mockWindow(window);
+  mockWindow(global.window);
 }
 
 export const ver = '__VERSION__';


### PR DESCRIPTION
### Changes

- Fix #89, also closes #84
- Move to GitHub Actions (related to #90)