### PR TITLE
feat: disable `package-lock.json`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Since we ignored `package-lock.json` in `.gitignore`. Then we should turn off the lock file in `.npmrc` as well.