### PR TITLE
index: export a function to re-initialize mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ coverage
 package-lock.json
 yarn.lock
 lib
+.yarn
+.pnp.cjs
+.pnp.loader.mjs

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ Add that file to your `setupFiles` array:
 }
 ```
 
+## Reset
+
+If you reset the jest mocks (for example, with `jest.resetAllMocks()`), you can
+call `setupJestCanvasMock()` to re-create it.
+
+```
+import { setupJestCanvasMock } from 'jest-canvas-mock';
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  setupJestCanvasMock();
+});
+```
+
 ## Mock Strategy
 
 This mock strategy implements all the canvas functions and actually verifies the parameters. If a

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -2,7 +2,7 @@
  * test canvas
  */
 
-import { ver, setJestCanvasMock } from '../src';
+import { ver, setupJestCanvasMock } from '../src';
 import pkg from '../package.json';
 
 let canvas;
@@ -17,11 +17,11 @@ describe('canvas', () => {
   });
 });
 
-describe('setupCanvasMock', () => {
+describe('setupJestCanvasMock', () => {
   it('should setup after resetAllMocks', () => {
     jest.resetAllMocks();
     expect(document.createElement('canvas').getContext('2d')).toBe(undefined);
-    setJestCanvasMock();
+    setupJestCanvasMock();
     expect(document.createElement('canvas').getContext('2d')).toHaveProperty(
       'createImageData'
     );

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -2,7 +2,7 @@
  * test canvas
  */
 
-import { ver, setupCanvasMock } from '../src';
+import { ver, setJestCanvasMock } from '../src';
 import pkg from '../package.json';
 
 let canvas;
@@ -21,7 +21,7 @@ describe('setupCanvasMock', () => {
   it('should setup after resetAllMocks', () => {
     jest.resetAllMocks();
     expect(document.createElement('canvas').getContext('2d')).toBe(undefined);
-    setupCanvasMock();
+    setJestCanvasMock();
     expect(document.createElement('canvas').getContext('2d')).toHaveProperty(
       'createImageData'
     );

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -2,7 +2,7 @@
  * test canvas
  */
 
-import { ver } from '../src';
+import { ver, setupCanvasMock } from '../src';
 import pkg from '../package.json';
 
 let canvas;
@@ -14,5 +14,16 @@ beforeEach(() => {
 describe('canvas', () => {
   it('should have correct version', () => {
     expect(ver).toBe(pkg.version);
+  });
+});
+
+describe('setupCanvasMock', () => {
+  it('should setup after resetAllMocks', () => {
+    jest.resetAllMocks();
+    expect(document.createElement('canvas').getContext('2d')).toBe(undefined);
+    setupCanvasMock();
+    expect(document.createElement('canvas').getContext('2d')).toHaveProperty(
+      'createImageData'
+    );
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,6 @@ if (typeof window !== 'undefined') {
 
 export const ver = '__VERSION__';
 
-export function setJestCanvasMock(window) {
+export function setupJestCanvasMock(window) {
   mockWindow(window || global.window);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ if (typeof window !== 'undefined') {
 }
 
 export const ver = '__VERSION__';
-export function setupCanvasMock(window) {
+
+export function setJestCanvasMock(window) {
   mockWindow(window || global.window);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,6 @@ if (typeof window !== 'undefined') {
 }
 
 export const ver = '__VERSION__';
+export function setupCanvasMock() {
+  mockWindow(global.window);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,6 @@ if (typeof window !== 'undefined') {
 }
 
 export const ver = '__VERSION__';
-export function setupCanvasMock() {
-  mockWindow(global.window);
+export function setupCanvasMock(window) {
+  mockWindow(window || global.window);
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-export function setJestCanvasMock(window?: Window) {}
+export function setupJestCanvasMock(window?: Window) {}
 
 export interface CanvasRenderingContext2DEvent {
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-export function setupCanvasMock(window?: Window) {}
+export function setJestCanvasMock(window?: Window) {}
 
 export interface CanvasRenderingContext2DEvent {
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-export function setupCanvasMock() {}
+export function setupCanvasMock(window?: Window) {}
 
 export interface CanvasRenderingContext2DEvent {
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,5 @@
+export function setupCanvasMock() {}
+
 export interface CanvasRenderingContext2DEvent {
   /**
    * This is the type of canvas event that occured.


### PR DESCRIPTION
This allows consumers of this library to use the mock with `jest.resetAllMocks()`

Should allow workarounds for https://github.com/hustcc/jest-canvas-mock/issues/72