### PR TITLE
Fix setupJestCanvasMock type declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ canvas.toDataURL.mockReturnValueOnce(
 - [@lekha](https://github.com/lekha)
 - [@yonatankra](https://github.com/yonatankra)
 - [@LitoMore](https://github.com/LitoMore)
+- [@hrd543](https://github.com/hrd543)
 
 ## License
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-export function setupJestCanvasMock(window?: Window) {}
+export function setupJestCanvasMock(window?: Window): void
 
 export interface CanvasRenderingContext2DEvent {
   /**


### PR DESCRIPTION
Currently, setupJestCanvasMock is typed using `{}`, however this causes a TypeScript error, TS1183: An implementation cannot be declared in ambient contexts.
Instead, use `void` as the return type to fix this error

This should fix #107 