### PR TITLE
#112: fixed parameter order in DOMException

### DIFF
--- a/__tests__/classes/CanvasGradient.js
+++ b/__tests__/classes/CanvasGradient.js
@@ -24,10 +24,12 @@ describe('CanvasGradient', () => {
 
   [Infinity, NaN, -Infinity].forEach((value) => {
     test('CanvasGradient should throw if offset is ' + value, () => {
-      expect(() => {
+      const fn = () => {
         var grd = ctx.createLinearGradient(1, 2, 3, 4);
         grd.addColorStop(value, 'blue');
-      }).toThrow(DOMException);
+      };
+      expect(fn).toThrow(DOMException);
+      expect(fn).toThrow('is outside the range');
     });
   });
 

--- a/__tests__/classes/CanvasRenderingContext2D.addHitRegion.js
+++ b/__tests__/classes/CanvasRenderingContext2D.addHitRegion.js
@@ -19,13 +19,15 @@ describe('addHitRegion', () => {
   });
 
   it('should throw if called with no parameters', () => {
-    expect(() => ctx.addHitRegion()).toThrow(DOMException);
+    const fn = () => ctx.addHitRegion();
+    expect(fn).toThrow(DOMException);
+    expect(fn).toThrow('Both id and control are null');
   });
 
   it("should throw if fillRule is set and isn't 'evenodd' or 'nonzero'", () => {
-    expect(() =>
-      ctx.addHitRegion({ id: 'test', fillRule: 'wrong!' })
-    ).toThrow();
+    const fn = () => ctx.addHitRegion({ id: 'test', fillRule: 'wrong!' });
+    expect(fn).toThrow(TypeError);
+    expect(fn).toThrow('is not a valid enum value of type CanvasFillRule');
   });
 
   it('should not throw if fillRule is valid', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.arc.js
+++ b/__tests__/classes/CanvasRenderingContext2D.arc.js
@@ -18,7 +18,7 @@ describe('arc', () => {
     expect(ctx.arc).toBeCalled();
   });
 
-  it("shouldn't accept parameters less than 7", () => {
+  it("shouldn't accept parameters less than 5", () => {
     expect(() => ctx.arc()).toThrow(TypeError);
     expect(() => ctx.arc(1)).toThrow(TypeError);
     expect(() => ctx.arc(1, 2)).toThrow(TypeError);
@@ -27,7 +27,9 @@ describe('arc', () => {
   });
 
   it('should throw when radius is negative', () => {
-    expect(() => ctx.arc(1, 2, -1, 4, 5)).toThrow(DOMException);
+    const fn = () => ctx.arc(1, 2, -1, 4, 5);
+    expect(fn).toThrow(DOMException);
+    expect(fn).toThrow('The radius provided (-1) is negative.');
   });
 
   it('should not throw if any value is `NaN`', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.arcTo.js
+++ b/__tests__/classes/CanvasRenderingContext2D.arcTo.js
@@ -19,11 +19,17 @@ describe('arcTo', () => {
   });
 
   it("shouldn't accept parameters less than 5", () => {
-    expect(() => ctx.arcTo(1, 2, 3)).toThrow(DOMException);
+    expect(() => ctx.arcTo()).toThrow(TypeError);
+    expect(() => ctx.arcTo(1)).toThrow(TypeError);
+    expect(() => ctx.arcTo(1, 2)).toThrow(TypeError);
+    expect(() => ctx.arcTo(1, 2, 3)).toThrow(TypeError);
+    expect(() => ctx.arcTo(1, 2, 3, 4)).toThrow(TypeError);
   });
 
   it('should throw when radius is negative', () => {
-    expect(() => ctx.arcTo(1, 2, -1, 3, -1)).toThrow(TypeError);
+    const fn = () => ctx.arcTo(1, 2, 3, 4, -1);
+    expect(fn).toThrow(DOMException);
+    expect(fn).toThrow('The radius provided (-1) is negative.');
   });
 
   it('should accept 5 parameters regardless of type', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.createImagePattern.js
+++ b/__tests__/classes/CanvasRenderingContext2D.createImagePattern.js
@@ -63,7 +63,9 @@ describe('createImagePattern', () => {
   it('should not create a pattern if the image bitmap is closed', () => {
     const bmp = new ImageBitmap(400, 300);
     bmp.close();
-    expect(() => ctx.createPattern(bmp, 'repeat')).toThrow(DOMException);
+    const fn = () => ctx.createPattern(bmp, 'repeat');
+    expect(fn).toThrow(DOMException);
+    expect(fn).toThrow('The image source is detached.');
   });
 
   it('should create a valid pattern for all repeat types', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.createRadialGradient.js
+++ b/__tests__/classes/CanvasRenderingContext2D.createRadialGradient.js
@@ -43,13 +43,16 @@ describe('createRadialGradient', () => {
     );
   });
 
-  it('should not create a radial gradient if any of the radius values are < 0', () => {
-    expect(() => ctx.createRadialGradient(0, 0, -1, 0, 0, 0)).toThrow(
-      DOMException
-    );
-    expect(() => ctx.createRadialGradient(0, 0, 0, 0, 0, -1)).toThrow(
-      DOMException
-    );
+  it('should not create a radial gradient if r0 value is < 0', () => {
+    const fn = () => ctx.createRadialGradient(0, 0, -1, 0, 0, 0);
+    expect(fn).toThrow(DOMException);
+    expect(fn).toThrow('The r0 provided is less than 0.');
+  });
+
+  it('should not create a radial gradient if r1 value is < 0', () => {
+    const fn = () => ctx.createRadialGradient(0, 0, 0, 0, 0, -1);
+    expect(fn).toThrow(DOMException);
+    expect(fn).toThrow('The r1 provided is less than 0.');
   });
 
   it('should create a radial gradient with string values', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.drawImage.js
+++ b/__tests__/classes/CanvasRenderingContext2D.drawImage.js
@@ -36,7 +36,9 @@ describe('drawImage', () => {
   it('should not draw if the image bitmap is closed', () => {
     const bmp = new ImageBitmap(100, 100);
     bmp.close();
-    expect(() => ctx.drawImage(bmp, 1, 2)).toThrow(DOMException);
+    const fn = () => ctx.drawImage(bmp, 1, 2);
+    expect(fn).toThrow(DOMException);
+    expect(fn).toThrow('The image source is detached.');
   });
 
   it('should accept 3, 5, and 9 parameters', () => {

--- a/__tests__/classes/CanvasRenderingContext2D.ellipse.js
+++ b/__tests__/classes/CanvasRenderingContext2D.ellipse.js
@@ -28,9 +28,16 @@ describe('ellipse', () => {
     expect(() => ctx.ellipse(1, 2, 3, 4, 5, 6)).toThrow(TypeError);
   });
 
-  it('should throw when radius is negative', () => {
-    expect(() => ctx.ellipse(1, 2, -1, 4, 5, 6, 7)).toThrow(DOMException);
-    expect(() => ctx.ellipse(1, 2, 3, -1, 5, 6, 7)).toThrow(DOMException);
+  it('should throw when major axis radius is negative', () => {
+    const fn = () => ctx.ellipse(1, 2, -1, 4, 5, 6, 7);
+    expect(fn).toThrow(DOMException);
+    expect(fn).toThrow('The major-axis radius provided (-1) is negative.');
+  });
+
+  it('should throw when minor axis radius is negative', () => {
+    const fn = () => ctx.ellipse(1, 2, 3, -1, 5, 6, 7);
+    expect(fn).toThrow(DOMException);
+    expect(fn).toThrow('The minor-axis radius provided (-1) is negative.');
   });
 
   it('should not throw if any value is `NaN`', () => {

--- a/src/classes/CanvasGradient.js
+++ b/src/classes/CanvasGradient.js
@@ -9,10 +9,10 @@ export default class CanvasGradient {
     const numoffset = Number(offset);
     if (!Number.isFinite(numoffset) || numoffset < 0 || numoffset > 1) {
       throw new DOMException(
-        'IndexSizeError',
         "Failed to execute 'addColorStop' on 'CanvasGradient': The provided value ('" +
           numoffset +
-          "') is outside the range (0.0, 1.0)"
+          "') is outside the range (0.0, 1.0)",
+        'IndexSizeError'
       );
     }
     try {

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -188,10 +188,10 @@ export default class CanvasRenderingContext2D {
       options;
     if (!path && !id)
       throw new DOMException(
-        'ConstraintError',
         "Failed to execute 'addHitRegion' on '" +
           this.constructor.name +
-          "': Both id and control are null."
+          "': Both id and control are null.",
+        'ConstraintError'
       );
     if (fillRule && fillRule !== 'evenodd' && fillRule !== 'nonzero')
       throw new TypeError(
@@ -242,12 +242,12 @@ export default class CanvasRenderingContext2D {
 
     if (Number(radius) < 0)
       throw new DOMException(
-        'IndexSizeError',
         "Failed to execute 'arc' on '" +
           this.constructor.name +
           "': The radius provided (" +
           radius +
-          ') is negative.'
+          ') is negative.',
+        'IndexSizeError'
       );
 
     const event = createCanvasEvent('arc', getTransformSlice(this), {
@@ -264,8 +264,7 @@ export default class CanvasRenderingContext2D {
 
   arcTo(cpx1, cpy1, cpx2, cpy2, radius) {
     if (arguments.length < 5)
-      throw new DOMException(
-        'IndexSizeError',
+      throw new TypeError(
         "Failed to execute 'arcTo' on '" +
           this.constructor.name +
           "': 5 arguments required, but only " +
@@ -285,12 +284,13 @@ export default class CanvasRenderingContext2D {
     )
       return;
     if (radiusResult < 0)
-      throw new TypeError(
+      throw new DOMException(
         "Failed to execute 'arcTo' on '" +
           this.constructor.name +
           "': The radius provided (" +
           radius +
-          ') is negative.'
+          ') is negative.',
+        'IndexSizeError'
       );
 
     const event = createCanvasEvent('arcTo', getTransformSlice(this), {
@@ -553,8 +553,8 @@ export default class CanvasRenderingContext2D {
       if (image instanceof ImageBitmap) {
         if (image._closed)
           throw new DOMException(
-            'InvalidStateError',
-            "Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The image source is detached."
+            "Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The image source is detached.",
+            'InvalidStateError'
           );
         this._events.push(event);
         return new CanvasPattern();
@@ -616,17 +616,17 @@ export default class CanvasRenderingContext2D {
       );
     if (r0Result < 0)
       throw new DOMException(
-        'IndexSizeError',
         "Failed to execute 'createRadialGradient' on '" +
           this.constructor.name +
-          "': The r0 provided is less than 0."
+          "': The r0 provided is less than 0.",
+        'IndexSizeError'
       );
     if (r1Result < 0)
       throw new DOMException(
-        'IndexSizeError',
         "Failed to execute 'createRadialGradient' on '" +
           this.constructor.name +
-          "': The r1 provided is less than 0."
+          "': The r1 provided is less than 0.",
+        'IndexSizeError'
       );
 
     const event = createCanvasEvent(
@@ -746,8 +746,8 @@ export default class CanvasRenderingContext2D {
     if (img instanceof ImageBitmap) {
       if (img._closed)
         throw new DOMException(
-          'InvalidStateError',
-          "DOMException: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The image source is detached."
+          "DOMException: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The image source is detached.",
+          'InvalidStateError'
         );
       valid = true;
     }
@@ -864,21 +864,21 @@ export default class CanvasRenderingContext2D {
 
     if (Number(radiusX) < 0)
       throw new DOMException(
-        'IndexSizeError',
         "Failed to execute 'ellipse' on '" +
           this.constructor.name +
           "': The major-axis radius provided (" +
           radiusX +
-          ') is negative.'
+          ') is negative.',
+        'IndexSizeError'
       );
     if (Number(radiusY) < 0)
       throw new DOMException(
-        'IndexSizeError',
         "Failed to execute 'ellipse' on '" +
           this.constructor.name +
           "': The minor-axis radius provided (" +
           radiusY +
-          ') is negative.'
+          ') is negative.',
+        'IndexSizeError'
       );
 
     const event = createCanvasEvent('ellipse', getTransformSlice(this), {


### PR DESCRIPTION
fixes #112

- correct parameter order of DOMException
- fixed swapped TypeError/DOMException in arcTo()
- added unit tests for the message strings of all thrown DOMExceptions