### PR TITLE
Add reset function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # jest-canvas-mock
 
 > Mock `canvas` when run unit test cases with jest. For more browser environment.
+>
 > - [jest-random-mock](https://github.com/hustcc/jest-random-mock) Mock `Math.random` in jest, with deterministic random generator.
 > - [jest-date-mock](https://github.com/hustcc/jest-date-mock) Mock `Date` when run unit test with jest, test `Date` easily.
 

--- a/__tests__/classes/CanvasRenderingContext2D.reset.js
+++ b/__tests__/classes/CanvasRenderingContext2D.reset.js
@@ -1,0 +1,24 @@
+let canvas;
+let ctx;
+
+beforeEach(() => {
+  canvas = document.createElement('canvas');
+  ctx = canvas.getContext('2d');
+  canvas.width = 400;
+  canvas.height = 300;
+});
+
+describe('reset', () => {
+  it('should be a function', () => {
+    expect(typeof ctx.reset).toBe('function');
+  });
+
+  it('should be callable', () => {
+    ctx.rect();
+    expect(ctx.reset).toHaveBeenCalled();
+  });
+
+  it('should throw if any parameters are given', () => {
+    expect(() => ctx.rect(1)).toThrow(TypeError);
+  });
+});

--- a/__tests__/classes/CanvasRenderingContext2D.reset.js
+++ b/__tests__/classes/CanvasRenderingContext2D.reset.js
@@ -14,11 +14,11 @@ describe('reset', () => {
   });
 
   it('should be callable', () => {
-    ctx.rect();
+    ctx.reset();
     expect(ctx.reset).toHaveBeenCalled();
   });
 
   it('should throw if any parameters are given', () => {
-    expect(() => ctx.rect(1)).toThrow(TypeError);
+    expect(() => ctx.reset(1)).toThrow(TypeError);
   });
 });

--- a/__tests__/classes/CanvasRenderingContext2D.reset.js
+++ b/__tests__/classes/CanvasRenderingContext2D.reset.js
@@ -19,6 +19,6 @@ describe('reset', () => {
   });
 
   it('should throw if any parameters are given', () => {
-    expect(() => ctx.reset(1)).toThrow(TypeError);
+    expect(() => ctx.reset(1)).toThrow(/Failed to execute 'reset' on/);
   });
 });

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -29,6 +29,7 @@ const testFuncs = [
   'fillRect',
   'strokeRect',
   'rect',
+  'reset',
   'roundRect',
   'resetTransform',
   'translate',
@@ -1444,6 +1445,21 @@ export default class CanvasRenderingContext2D {
 
     this._events.push(event);
     this._path.push(event);
+  }
+
+  reset() {
+    if (arguments.length > 0) {
+      throw new TypeError(
+        "Failed to execute 'reset' on '" +
+          this.constructor.name +
+          "': 0 arguments required, but " +
+          arguments.length +
+          ' present.'
+      );
+    }
+
+    const event = createCanvasEvent('reset')
+    this._events.push(event)
   }
 
   removeHitRegion(id) {

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -1458,8 +1458,8 @@ export default class CanvasRenderingContext2D {
       );
     }
 
-    const event = createCanvasEvent('reset')
-    this._events.push(event)
+    const event = createCanvasEvent('reset');
+    this._events.push(event);
   }
 
   removeHitRegion(id) {


### PR DESCRIPTION
I'd like to use this library, but my project uses [the reset function](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/reset) pretty heavily which is currently missing from this mock. This PR adds that function to the mock.