### PR TITLE
fix(CanvasRenderingContext2D): change miterLimit event type from 'lineWidth' to 'miterLimit'

### DIFF
--- a/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
+++ b/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
@@ -1280,7 +1280,7 @@ Array [
       0,
       0,
     ],
-    "type": "lineWidth",
+    "type": "miterLimit",
   },
 ]
 `;

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -1306,7 +1306,7 @@ export default class CanvasRenderingContext2D {
 
     if (Number.isFinite(result) && result > 0) {
       this._miterLimitStack[this._stackIndex] = result;
-      const event = createCanvasEvent('lineWidth', getTransformSlice(this), {
+      const event = createCanvasEvent('miterLimit', getTransformSlice(this), {
         value: result,
       });
       this._events.push(event);


### PR DESCRIPTION
Looks like a copy-paste bug which is causing lineWidth to return invalid values in canvases that set miterLimit.

Context:
I'll dig into repo styles and guidelines and make sure all the tests are passing in the morning before taking out of draft, but I'm using the package to test apache eCharts with my [jest-canvas-mock-compare](https://github.com/grafana/jest-canvas-mock-compare) package. I finally got around to looking into why the lineWidths are all 10x what they appear like in the browser, and after digging into the snapshot I found that eCharts is setting a miterLimit of 10 as a canvas default but a lineWidth of 1, and it looks like this package has a bug with miterLimit overwriting the lineWidth.

Expected is without a local pnpm patch, actual is with the patch:

<img width="1318" height="448" alt="image" src="https://github.com/user-attachments/assets/bb4d28c8-979f-421d-b2ed-cc5045775d6e" />

Patch:
```patch
diff --git a/lib/classes/CanvasRenderingContext2D.js b/lib/classes/CanvasRenderingContext2D.js
index e1e4b8fe31826baadbdce3f48ee2a68455de8910..a74fa1739406b1d0656263e4f3c244da8e8c1a15 100644
--- a/lib/classes/CanvasRenderingContext2D.js
+++ b/lib/classes/CanvasRenderingContext2D.js
@@ -779,7 +779,7 @@ class CanvasRenderingContext2D {
     const result = Number(value);
     if (Number.isFinite(result) && result > 0) {
       this._miterLimitStack[this._stackIndex] = result;
-      const event = (0, _createCanvasEvent.default)('lineWidth', getTransformSlice(this), {
+      const event = (0, _createCanvasEvent.default)('miterLimit', getTransformSlice(this), {
         value: result
       });
       this._events.push(event);
```
